### PR TITLE
Use `pygame.display.get_desktop_sizes()` with fallback when maximizing window

### DIFF
--- a/bernoulli_dual_view_refactored.py
+++ b/bernoulli_dual_view_refactored.py
@@ -1168,8 +1168,12 @@ class BernoulliSimulation:
                             self.window_controls.is_maximized = False
                         else:
                             # Maximize window
-                            info = pygame.display.Info()
-                            self.resize_window(info.current_w, info.current_h)
+                            try:
+                                w, h = pygame.display.get_desktop_sizes()[0]
+                            except (AttributeError, IndexError):
+                                info = pygame.display.Info()
+                                w, h = info.current_w, info.current_h
+                            self.resize_window(w, h)
                             self.window_controls.is_maximized = True
                         continue
                     elif action == "drag_start":
@@ -1214,8 +1218,12 @@ class BernoulliSimulation:
                         self.resize_window(WIDTH, HEIGHT)
                         self.window_controls.is_maximized = False
                     else:
-                        info = pygame.display.Info()
-                        self.resize_window(info.current_w, info.current_h)
+                        try:
+                            w, h = pygame.display.get_desktop_sizes()[0]
+                        except (AttributeError, IndexError):
+                            info = pygame.display.Info()
+                            w, h = info.current_w, info.current_h
+                        self.resize_window(w, h)
                         self.window_controls.is_maximized = True
             
             elif event.type == pygame.VIDEORESIZE:


### PR DESCRIPTION
### Motivation
- Ensure window maximize/fullscreen uses the modern `pygame.display.get_desktop_sizes()` API when available while preserving backward compatibility with older `pygame.display.Info()` behavior.

### Description
- Replace direct calls to `pygame.display.Info()` when maximizing the window (mouse maximize and `F11` toggle) with a `try`/`except` that attempts to use `pygame.display.get_desktop_sizes()[0]` and falls back to `pygame.display.Info()` on `AttributeError` or `IndexError`, then call `self.resize_window(w, h)` and update `self.window_controls.is_maximized` accordingly.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ea1d626c83309bba535b5d89106d)