### PR TITLE
Add desktop-resolution maximize helpers and unify maximize toggle behavior

### DIFF
--- a/bernoulli_dual_view_refactored.py
+++ b/bernoulli_dual_view_refactored.py
@@ -382,6 +382,31 @@ class BernoulliSimulation:
             
             self.ball_pos[0] = min(self.ball_pos[0], max_x)
             self.ball_pos[1] = min(self.ball_pos[1], max_y)
+
+    def get_desktop_resolution(self):
+        """Get desktop resolution with compatibility fallback for older pygame versions."""
+        try:
+            return pygame.display.get_desktop_sizes()[0]
+        except (AttributeError, IndexError):
+            modes = pygame.display.list_modes()
+            if modes and modes[0]:
+                return modes[0]
+            info = pygame.display.Info()
+            return info.current_w, info.current_h
+
+    def maximize_window(self):
+        """Resize window to desktop resolution and mark maximized state."""
+        w, h = self.get_desktop_resolution()
+        self.resize_window(w, h)
+        self.window_controls.is_maximized = True
+
+    def toggle_maximize_window(self):
+        """Toggle between default window size and maximized desktop size."""
+        if self.window_controls.is_maximized:
+            self.resize_window(WIDTH, HEIGHT)
+            self.window_controls.is_maximized = False
+        else:
+            self.maximize_window()
     
     def calculate_bernoulli_effect(self):
         """Calculate Bernoulli effect with improved accuracy"""
@@ -1162,19 +1187,7 @@ class BernoulliSimulation:
                         pygame.display.iconify()
                         continue
                     elif action == "maximize":
-                        if self.window_controls.is_maximized:
-                            # Restore to normal size
-                            self.resize_window(WIDTH, HEIGHT)
-                            self.window_controls.is_maximized = False
-                        else:
-                            # Maximize window
-                            try:
-                                w, h = pygame.display.get_desktop_sizes()[0]
-                            except (AttributeError, IndexError):
-                                info = pygame.display.Info()
-                                w, h = info.current_w, info.current_h
-                            self.resize_window(w, h)
-                            self.window_controls.is_maximized = True
+                        self.toggle_maximize_window()
                         continue
                     elif action == "drag_start":
                         self.window_controls.dragging_window = True
@@ -1214,17 +1227,7 @@ class BernoulliSimulation:
                     return False
                 elif event.key == pygame.K_F11:
                     # Toggle fullscreen
-                    if self.window_controls.is_maximized:
-                        self.resize_window(WIDTH, HEIGHT)
-                        self.window_controls.is_maximized = False
-                    else:
-                        try:
-                            w, h = pygame.display.get_desktop_sizes()[0]
-                        except (AttributeError, IndexError):
-                            info = pygame.display.Info()
-                            w, h = info.current_w, info.current_h
-                        self.resize_window(w, h)
-                        self.window_controls.is_maximized = True
+                    self.toggle_maximize_window()
             
             elif event.type == pygame.VIDEORESIZE:
                 self.resize_window(event.w, event.h)


### PR DESCRIPTION
### Motivation
- Centralize and simplify window maximize/restore logic into reusable helpers to avoid duplicated compatibility code across event handlers.
- Provide a robust fallback for obtaining desktop resolution that works with older and newer `pygame` versions.
- Make maximize state explicit via `window_controls.is_maximized` to ensure consistent behavior when toggling or resizing windows.

### Description
- Added `get_desktop_resolution()` to obtain the desktop size with fallbacks to `pygame.display.list_modes()` and `pygame.display.Info()` for compatibility with older `pygame` releases.
- Added `maximize_window()` and `toggle_maximize_window()` helper methods that call `resize_window()` and update `window_controls.is_maximized` accordingly.
- Replaced inline maximize/restore code in mouse `MOUSEBUTTONDOWN` handling and `F11` key handling with a call to `toggle_maximize_window()` to remove duplication and improve readability.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ec2b40748330b79741dd29e01e1d)